### PR TITLE
modify systemdScript template

### DIFF
--- a/graftcp-local/vendor/github.com/kardianos/service/service_systemd_linux.go
+++ b/graftcp-local/vendor/github.com/kardianos/service/service_systemd_linux.go
@@ -160,7 +160,7 @@ ConditionFileIsExecutable={{.Path|cmdEscape}}
 [Service]
 StartLimitInterval=5
 StartLimitBurst=10
-ExecStart={{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
+ExecStart=/bin/bash -c {{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
 {{if .ChRoot}}RootDirectory={{.ChRoot|cmd}}{{end}}
 {{if .WorkingDirectory}}WorkingDirectory={{.WorkingDirectory|cmdEscape}}{{end}}
 {{if .UserName}}User={{.UserName}}{{end}}


### PR DESCRIPTION
Without /bin/bash -c ,systemd may not know how to start the graftcp-local and "systemctl start graftcp-local.service" will fail.