### PR TITLE
Check null pointer for strdup

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -41,6 +41,8 @@ static int config_local_addr(const char *key, const char *value, struct graftcp_
 	if (strlen(value) <= 0)
 		return -1;
 	conf->local_addr = strdup(value);
+	if (!conf->local_addr)
+		return -1;
 	return 0;
 }
 
@@ -59,18 +61,24 @@ static int config_local_port(const char *key, const char *value, struct graftcp_
 static int config_pipe_path(const char *key, const char *value, struct graftcp_conf *conf)
 {
 	conf->pipe_path = strdup(value);
+	if (!conf->pipe_path)
+		return -1;
 	return 0;
 }
 
 static int config_blackip_file_path(const char *key, const char *value, struct graftcp_conf *conf)
 {
 	conf->blackip_file_path = strdup(value);
+	if (!conf->blackip_file_path)
+		return -1;
 	return 0;
 }
 
 static int config_whiteip_file_path(const char *key, const char *value, struct graftcp_conf *conf)
 {
 	conf->whiteip_file_path = strdup(value);
+	if (!conf->whiteip_file_path)
+		return -1;
 	return 0;
 }
 

--- a/graftcp.c
+++ b/graftcp.c
@@ -582,7 +582,7 @@ int client_main(int argc, char **argv)
 		case 'a':
 			cmd_conf.local_addr = strdup(optarg);
 			if (cmd_conf.local_addr == NULL) {
-				perror("strdup failed to allocate memory");
+				perror("strdup");
 				exit(1);
 			}
 			break;
@@ -593,21 +593,21 @@ int client_main(int argc, char **argv)
 		case 'f':
 			cmd_conf.pipe_path = strdup(optarg);
 			if (cmd_conf.pipe_path == NULL) {
-				perror("strdup failed to allocate memory");
+				perror("strdup");
 				exit(1);
 			}
 			break;
 		case 'b':
 			cmd_conf.blackip_file_path = strdup(optarg);
 			if (cmd_conf.blackip_file_path == NULL) {
-				perror("strdup failed to allocate memory");
+				perror("strdup");
 				exit(1);
 			}
 			break;
 		case 'w':
 			cmd_conf.whiteip_file_path = strdup(optarg);
 			if (cmd_conf.whiteip_file_path == NULL) {
-				perror("strdup failed to allocate memory");
+				perror("strdup");
 				exit(1);
 			}
 			break;
@@ -618,14 +618,14 @@ int client_main(int argc, char **argv)
 		case 'c':
 			conf_file_path = strdup(optarg);
 			if (conf_file_path == NULL) {
-				perror("strdup failed to allocate memory");
+				perror("strdup");
 				exit(1);
 			}
 			break;
 		case 'u':
 			cmd_conf.username = strdup(optarg);
 			if (cmd_conf.username == NULL) {
-				perror("strdup failed to allocate memory");
+				perror("strdup");
 				exit(1);
 			}
 			break;
@@ -695,7 +695,7 @@ int client_main(int argc, char **argv)
 		run_uid = pent->pw_uid;
 		run_home = strdup(pent->pw_dir);
 		if (run_home == NULL) {
-			perror("strdup failed to allocate memory");
+			perror("strdup");
 			exit(1);
 		}
 	}

--- a/graftcp.c
+++ b/graftcp.c
@@ -581,6 +581,10 @@ int client_main(int argc, char **argv)
 		switch (opt) {
 		case 'a':
 			cmd_conf.local_addr = strdup(optarg);
+			if (cmd_conf.local_addr == NULL) {
+				perror("strdup failed to allocate memory");
+				exit(1);
+			}
 			break;
 		case 'p':
 			cmd_conf.local_port = malloc(sizeof(*cmd_conf.local_port));
@@ -588,12 +592,24 @@ int client_main(int argc, char **argv)
 			break;
 		case 'f':
 			cmd_conf.pipe_path = strdup(optarg);
+			if (cmd_conf.pipe_path == NULL) {
+				perror("strdup failed to allocate memory");
+				exit(1);
+			}
 			break;
 		case 'b':
 			cmd_conf.blackip_file_path = strdup(optarg);
+			if (cmd_conf.blackip_file_path == NULL) {
+				perror("strdup failed to allocate memory");
+				exit(1);
+			}
 			break;
 		case 'w':
 			cmd_conf.whiteip_file_path = strdup(optarg);
+			if (cmd_conf.whiteip_file_path == NULL) {
+				perror("strdup failed to allocate memory");
+				exit(1);
+			}
 			break;
 		case 'n':
 			cmd_conf.ignore_local = malloc(sizeof(*cmd_conf.ignore_local));
@@ -601,9 +617,17 @@ int client_main(int argc, char **argv)
 			break;
 		case 'c':
 			conf_file_path = strdup(optarg);
+			if (conf_file_path == NULL) {
+				perror("strdup failed to allocate memory");
+				exit(1);
+			}
 			break;
 		case 'u':
 			cmd_conf.username = strdup(optarg);
+			if (cmd_conf.username == NULL) {
+				perror("strdup failed to allocate memory");
+				exit(1);
+			}
 			break;
 		case 'V':
 			fprintf(stderr, "graftcp %s\n", VERSION);
@@ -670,6 +694,10 @@ int client_main(int argc, char **argv)
 		run_gid = pent->pw_gid;
 		run_uid = pent->pw_uid;
 		run_home = strdup(pent->pw_dir);
+		if (run_home == NULL) {
+			perror("strdup failed to allocate memory");
+			exit(1);
+		}
 	}
 
 	init(&conf, argc - optind, argv + optind);


### PR DESCRIPTION
The library function `strdup` may return null pointers, so I added some checks.
