### PR TITLE
Fix auto mode skipping HTTP proxy when socks5 fails

### DIFF
--- a/local/local.go
+++ b/local/local.go
@@ -229,9 +229,15 @@ func (l *Local) HandleConn(conn *net.TCPConn) error {
 		return fmt.Errorf("bad dialer")
 	}
 	destConn, err := dialer.Dial("tcp", destAddr)
-	if err != nil && l.selectMode == AutoSelectMode { // AutoSelectMode try direct
-		log.Infof("dial %s direct", destAddr)
-		destConn, err = net.Dial("tcp", destAddr)
+	if err != nil && l.selectMode == AutoSelectMode {
+		if l.httpProxyDialer != nil && dialer != l.httpProxyDialer {
+			log.Infof("try http_proxy for %s", destAddr)
+			destConn, err = l.httpProxyDialer.Dial("tcp", destAddr)
+		}
+		if err != nil {
+			log.Infof("dial %s direct", destAddr)
+			destConn, err = net.Dial("tcp", destAddr)
+		}
 	}
 	if err != nil {
 		log.Errorf("dialer.Dial(%s) err: %s", destAddr, err.Error())


### PR DESCRIPTION
## Summary
- In auto select mode, when socks5 proxy fails, the fallback goes directly to direct connection, skipping the HTTP proxy entirely
- This makes `-http_proxy` flag ineffective under the default `auto` mode, since `socks5Dialer` is always non-nil (default `127.0.0.1:1080` resolves even with nothing listening)
- Fix: try `httpProxyDialer` before falling back to direct connection

## Test plan
- [x] `graftcp-local -http_proxy=<proxy>` + `graftcp curl https://...` now routes through HTTP proxy
- [x] Verified both IPv4 and IPv6 connections work
- [x] Direct fallback still works when both socks5 and HTTP proxy fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)